### PR TITLE
Count the right amount of pipelineruns

### DIFF
--- a/validatedpatterns_tests/interop/components.py
+++ b/validatedpatterns_tests/interop/components.py
@@ -322,7 +322,7 @@ def validate_pipelineruns(
         logger.info(f"Passed pipelineruns: {passed_pipelineruns}")
 
         if (len(failed_pipelineruns) + len(passed_pipelineruns)) == len(
-            expected_pipelines
+            expected_pipelineruns
         ):
             break
         else:


### PR DESCRIPTION
Without this we'll end up in a loop and a timeout with IE 2.0 because it
is a pattern that has a large pipelinerun and that does not have the
same pipelineruns as it has pipelines.
